### PR TITLE
Add json-loader, required by rollbar.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2474,6 +2474,11 @@
       "from": "jsesc@>=0.5.0 <0.6.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
     },
+    "json-loader": {
+      "version": "0.5.4",
+      "from": "json-loader@>=0.5.4 <0.6.0",
+      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.4.tgz"
+    },
     "json-schema": {
       "version": "0.2.2",
       "from": "json-schema@0.2.2",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "eslint-plugin-jsx-a11y": "^1.5.5",
     "eslint-plugin-react": "^5.2.2",
     "foreman": "^1.4.1",
+    "json-loader": "^0.5.4",
     "nodemon": "^1.9.2",
     "webpack-dev-server": "^1.14.1"
   }


### PR DESCRIPTION
Add json-loader, required by rollbar, to prevent error on startup:

ERROR in ./~/rollbar/lib/notifier.js
Module not found: Error: Cannot resolve module 'json' in ...@./~/rollbar/lib/notifier.js 14:18-44