### PR TITLE
Fix rollbar not finding fs module.

### DIFF
--- a/webpack/config.js
+++ b/webpack/config.js
@@ -38,6 +38,9 @@ const config = {
       }
     ]
   },
+  node: {
+    fs: "empty"
+  },
   resolve: {
     extensions: ['', '.js', '.jsx']
   },


### PR DESCRIPTION
The error in the server log:
ERROR in ./~/rollbar/lib/parser.js
Module not found: Error: Cannot resolve module 'fs' in [myProjectRoot]node_modules/rollbar/lib
 @ ./~/rollbar/lib/parser.js 7:9-22

The fix is done as per:
https://github.com/rollbar/node_rollbar/issues/89