### PR TITLE
Remove duplicate (and incorrect) graphql-server-express

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "express": "^4.14.0",
     "graphql": "^0.9.0",
     "graphql-server-express": "^0.6.0",
-    "graphql-server-express ": "^0.6.0",
     "graphql-tag": "^1.2.4",
     "graphql-tools": "^0.9.2",
     "json-loader": "^0.5.4",


### PR DESCRIPTION
Was trying to run this for the first time and found that `graphql-server-express` was duplicated in `package.json` and also had a trailing space which was causing `npm install` to fail